### PR TITLE
Add missing disqus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Cacti is a lightweight blogging theme based on the [Cactus](http://cactusformac.
     * Russian
 * Super clean and modern design
 * Twitter and Facebook integration
-* Support for Disqus comments
+* Support for [Disqus comments](#enable-disqus)
 * Google Analytics built-in
 
 ![Cacti](assets/inner-page.jpg)
@@ -81,3 +81,7 @@ In order to configure Cacti, you should copy the theme's `cacti.yaml` file into 
 
 
 Once this is done, you should be able to see the new theme on the frontend. Keep in mind any customizations made to the previous theme will not be reflected as all of the theme and templating information is now being pulled from the **cacti** folder.
+
+## Enable Disqus
+
+To enable comments with Disqus, add `disqus_shortname: YOUR_DISQUS_HANDLE` to the `user/config/site.yml`.

--- a/css/style.css
+++ b/css/style.css
@@ -562,6 +562,7 @@ Post List
 	font-size:13px;
 	font-weight:500;
 	margin-top: 40px;
+	margin-bottom: 40px;
 }
 
 #post-nav span {

--- a/templates/partials/disqus.html.twig
+++ b/templates/partials/disqus.html.twig
@@ -1,0 +1,14 @@
+{% if site.disqus_shortname %}
+    <div id="disqus_thread"></div>
+    <script type="text/javascript">
+        var disqus_shortname = "{{ site.disqus_shortname }}";
+        var disqus_identifier = "{{ site.disqus_shortname }}_{{ page.slug }}";
+        (function() {
+            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+        })();
+    </script>
+    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+{% endif %}

--- a/templates/post.html.twig
+++ b/templates/post.html.twig
@@ -24,7 +24,7 @@
         </section>
     </footer>
 
-    <nav id="post-nav">
+    <nav id="post-nav" class="clearfix">
         {% if not page.isFirst %}
         <span class="prev">
             <a href="{{ page.nextSibling.url }}"><span class="arrow">←</span> {{ page.nextSibling.title }}</a>


### PR DESCRIPTION
This adds support for Disqus comments. Closes #4.

Notes:
- used `site.disqus_shortname` like in the hpstr theme
- chose to use _shortname_page-slug_ as value for the [`disqus_identifier`](https://help.disqus.com/customer/portal/articles/472099-what-is-a-disqus-identifier-)
