### PR TITLE
Update base.html.twig

### DIFF
--- a/templates/partials/base.html.twig
+++ b/templates/partials/base.html.twig
@@ -16,12 +16,6 @@
   {% endblock %}
   {{ assets.css() }}
 
-  {% block javascripts %}
-      {% do assets.addJs('jquery',101) %}
-      {% do assets.addJs('theme://js/main.js',100) %}
-      {% do assets.addJs('theme://js/jquery.jscroll.min.js') %}
-  {% endblock %}
-  {{ assets.js() }}
 </head>
 <body>
 
@@ -46,5 +40,12 @@
     {% if site.analytics %}
     {% include 'partials/analytics.html.twig' %}
     {% endif %}
+    
+  {% block javascripts %}
+      {% do assets.addJs('jquery',101) %}
+      {% do assets.addJs('theme://js/main.js',100) %}
+      {% do assets.addJs('theme://js/jquery.jscroll.min.js') %}
+  {% endblock %}
+  {{ assets.js() }}
 </body>
 </html>


### PR DESCRIPTION
JavaScript assets should be rendered at the bottom of `<body>` for best practices.
