### PR TITLE
Remove default value for analytics, twitter and facebook in blueprints.yaml 

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -65,7 +65,7 @@ form:
         type: text
         size: medium
         label: Google Analytics Code
-        default: null
+        placeholder: 'UA-YOURCODE'
         validate:
           type: text
 
@@ -73,7 +73,7 @@ form:
         type: text
         size: medium
         label: Twitter
-        default: null
+        placeholder: '@getgrav'
         validate:
           type: text
 
@@ -81,7 +81,7 @@ form:
         type: text
         size: medium
         label: Facebook
-        default: null
+        placeholder: getgrav
         validate:
           type: text
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -65,7 +65,7 @@ form:
         type: text
         size: medium
         label: Google Analytics Code
-        default: 'UA-YOURCODE'
+        default: null
         validate:
           type: text
 
@@ -73,7 +73,7 @@ form:
         type: text
         size: medium
         label: Twitter
-        default: '@getgrav'
+        default: null
         validate:
           type: text
 
@@ -81,7 +81,7 @@ form:
         type: text
         size: medium
         label: Facebook
-        default: 'rockettheme'
+        default: null
         validate:
           type: text
 


### PR DESCRIPTION
I propose to remove the default values for `analytics`, `twitter` and `facebook` in `blueprints.yaml` to avoid continuously overwriting of manually set `null` values in the admin panel. The values are still preset to `UA-YOURCODE` / `'@getgrav'` / `rockettheme` due to `cacti.yaml`.