### PR TITLE
Compatibility to Highlight Plugin with line numbers

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -372,7 +372,7 @@ code.hljs {
     padding: 16px;
 }
 
-table {
+:not(.hljs)>table {
 	width: 100%;
 	margin: 40px 0;
 	border-collapse: collapse;
@@ -380,28 +380,28 @@ table {
 	line-height: 1.5em;
 }
 
-th,td {
+:not(.hljs)>table th,:not(.hljs)>table td {
 	text-align: left;
 	padding-right: 20px;
 	vertical-align: top;
 }
 
-table td,td {
+:not(.hljs)>table td,:not(.hljs)>table td {
 	border-spacing: none;
 	border-style: solid;
 	padding: 10px 15px;
 	border-width: 1px 0 0 0;
 }
 
-tr>td {
+:not(.hljs)>table tr>td {
 	border-top: 1px solid #eaeaea;
 }
 
-tr:nth-child(odd)>td {
+:not(.hljs)>table tr:nth-child(odd)>td {
 	background: #fcfcfc;
 }
 
-thead th,th {
+:not(.hljs)>table thead th,:not(.hljs)>table th {
 	text-align: left;
 	padding: 10px 15px;
 	height: 20px;


### PR DESCRIPTION
This change makes the *Cacti* theme compatible to line numbers by the *Highlight* plugin.

#### Code with line numbers before the change
![code before](https://user-images.githubusercontent.com/16349846/108919431-4ea86300-7633-11eb-840d-cbf7730e3824.png)
#### Code with line numbers after the change
![code after](https://user-images.githubusercontent.com/16349846/108919437-510abd00-7633-11eb-83fd-e204b2c1753b.png)
#### A table before the change
![table before](https://user-images.githubusercontent.com/16349846/108919419-46e8be80-7633-11eb-8615-38efb987457e.png)
#### A table after the change
![table after](https://user-images.githubusercontent.com/16349846/108919424-4bad7280-7633-11eb-8392-40ac6371a2d2.png)



